### PR TITLE
Fix misplaced module.exports in ES Modules build

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -14,8 +14,5 @@ module.exports = {
         },
       },
     ],
-  ],
-  plugins: [
-    BABEL_ENV === "commonjs" && "babel-plugin-add-module-exports"
-  ].filter(Boolean),
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "babel-core": "^7.0.0-bridge.0"
   },
   "scripts": {
-    "build:lib": "BABEL_ENV=commonjs babel --extensions '.ts' -d dist/lib src",
+    "build:lib:babel": "BABEL_ENV=commonjs babel --extensions '.ts' -d dist/lib src",
+    "build:lib:amend": "echo '\nmodule.exports = exports.default;' >> dist/lib/index.js",
+    "build:lib": "run-s build:lib:babel build:lib:amend",
     "build:es": "BABEL_ENV=esmodules babel --extensions '.ts' -d dist/es src",
     "build:types": "tsc -p tsconfig.dts.json",
     "build": "run-p build:lib build:es build:types",
@@ -70,7 +72,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^22.1.0",
     "babel-loader": "^7.1.5",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "husky": "^0.14.3",
     "jest": "^22.1.0",
     "lint-staged": "^7.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,4 +156,3 @@ const streamTag = (
 ) => new ReadableTagStream(strings, interpolations);
 
 export default streamTag;
-module.exports = streamTag;

--- a/yarn.lock
+++ b/yarn.lock
@@ -825,10 +825,6 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-module-exports@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz#9ae9a1f4a8dc67f0cdec4f4aeda1e43a5ff65e25"
-
 babel-plugin-istanbul@^4.1.5:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"


### PR DESCRIPTION
Hardcoded `module.exports` breaks webpack when importing the ES module build.

I've removed the `add-module-exports` plugin since it works only when the default export is the only export, which isn't the case for `stream-tag`.

Instead, I'm patching the commonjs build after the fact.

Related: https://github.com/webpack/webpack/issues/4039
